### PR TITLE
fix `kill-others` concurrently option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ function concurrent(scripts) {
     names: [],
   })
   const flags = [
-    '--kill-others-on-fail',
+    '--kill-others',
     `--prefix-colors "${colors.join(',')}"`,
     '--prefix "[{name}]"',
     `--names "${names.join(',')}"`,


### PR DESCRIPTION
Otherwise if a job dies, the others doesn't