### PR TITLE
Switch from doclets to ESDoc.

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -25,7 +25,8 @@
       "avatar_url": "https://avatars2.githubusercontent.com/u/7352279?v=3",
       "profile": "https://www.huy-nguyen.com/",
       "contributions": [
-        "doc"
+        "doc",
+        "infra"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -64,21 +64,18 @@ module.exports = {
 
 ### Available methods:
 
-API docs can be found [here][doclet]
+API docs can be found [here](https://doc.esdoc.org/github.com/kentcdodds/nps-utils/)
 
-- [concurrent](https://doclets.io/kentcdodds/nps-utils/master#dl-concurrent)
-- [concurrent.nps](https://doclets.io/kentcdodds/nps-utils/master#dl-concurrent.nps)
-- [series](https://doclets.io/kentcdodds/nps-utils/master#dl-series)
-- [series.nps](https://doclets.io/kentcdodds/nps-utils/master#dl-series.nps)
-- [runInNewWindow](https://doclets.io/kentcdodds/nps-utils/master#dl-runInNewWindow)
-- [runInNewWindow.nps](https://doclets.io/kentcdodds/nps-utils/master#dl-runInNewWindow.nps)
-- [rimraf](https://doclets.io/kentcdodds/nps-utils/master#dl-rimraf)
-- [ifWindows](https://doclets.io/kentcdodds/nps-utils/master#dl-ifWindows)
-- [ifNotWindows](https://doclets.io/kentcdodds/nps-utils/master#dl-ifNotWindows)
-- [copy](https://doclets.io/kentcdodds/nps-utils/master#dl-copy)
-- [mkdirp](https://doclets.io/kentcdodds/nps-utils/master#dl-mkdirp)
-- [open](https://doclets.io/kentcdodds/nps-utils/master#dl-open)
-- [crossEnv](https://doclets.io/kentcdodds/nps-utils/master#dl-crossEnv)
+- [concurrent](https://doc.esdoc.org/github.com/kentcdodds/nps-utils/function/index.html#static-function-concurrent)
+- [series](https://doc.esdoc.org/github.com/kentcdodds/nps-utils/function/index.html#static-function-series)
+- [runInNewWindow](https://doc.esdoc.org/github.com/kentcdodds/nps-utils/function/index.html#static-function-runInNewWindow)
+- [rimraf](https://doc.esdoc.org/github.com/kentcdodds/nps-utils/function/index.html#static-function-rimraf)
+- [ifWindows](https://doc.esdoc.org/github.com/kentcdodds/nps-utils/function/index.html#static-function-ifWindows)
+- [ifNotWindows](https://doc.esdoc.org/github.com/kentcdodds/nps-utils/function/index.html#static-function-ifNotWindows)
+- [copy](https://doc.esdoc.org/github.com/kentcdodds/nps-utils/function/index.html#static-function-copy)
+- [mkdirp](https://doc.esdoc.org/github.com/kentcdodds/nps-utils/function/index.html#static-function-mkdirp)
+- [open](https://doc.esdoc.org/github.com/kentcdodds/nps-utils/function/index.html#static-function-open)
+- [crossEnv](https://doc.esdoc.org/github.com/kentcdodds/nps-utils/function/index.html#static-function-crossEnv)
 
 `nps` also exports [`common-tags`][common-tags] as `commonTags` which can be
 really helpful for long scripts or descriptions.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ list them here!
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/nps-utils/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/nps-utils/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/nps-utils/commits?author=kentcdodds "Tests") | [<img src="https://avatars2.githubusercontent.com/u/7352279?v=3" width="100px;"/><br /><sub>Huy Nguyen</sub>](https://www.huy-nguyen.com/)<br />[📖](https://github.com/kentcdodds/nps-utils/commits?author=huy-nguyen "Documentation") |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/nps-utils/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/nps-utils/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/kentcdodds/nps-utils/commits?author=kentcdodds) | [<img src="https://avatars2.githubusercontent.com/u/7352279?v=3" width="100px;"/><br /><sub>Huy Nguyen</sub>](https://www.huy-nguyen.com/)<br />[📖](https://github.com/kentcdodds/nps-utils/commits?author=huy-nguyen) 🚇 |
 | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/esdoc.json
+++ b/esdoc.json
@@ -1,0 +1,4 @@
+{
+  "source": "./src",
+  "destination": "./docs"
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "codecov": "^1.0.1",
     "commitizen": "^2.8.6",
     "cz-conventional-changelog": "^2.0.0",
+    "esdoc": "^0.5.2",
     "eslint": "^3.16.1",
     "eslint-config-kentcdodds": "^12.0.0",
     "husky": "^0.13.1",


### PR DESCRIPTION
The current docs link is broken because `jsdoc`, which is used by doclets.io, cannot parse JSDoc in
ES6 file. ESDoc is capable of doing that and also offers free hosting. After merging into `master`, generate the online ESDoc [here](https://doc.esdoc.org/-/generate.html).

Closes #8