### PR TITLE
export shellEscape

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ export {
   commonTags,
   setColors,
   includePackage,
+  shellEscape,
 }
 
 /**


### PR DESCRIPTION
Rationale:
  * it is very useful for writing commands from scripts
  * nps-utils already imports it
  * no need to import as well, no need to add to package dependencies
