### PR TITLE
Made "releases" page link absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # CHANGELOG
 
 The changelog is automatically updated using [semantic-release](https://github.com/semantic-release/semantic-release).
-You can see it on the [releases page](../releases).
+You can see it on the [releases page](https://github.com/kentcdodds/nps-utils/releases).
+


### PR DESCRIPTION
The url for the [`CHANGELOG.md`](https://github.com/kentcdodds/nps-utils/blob/master/CHANGELOG.md) is `https://github.com/kentcdodds/nps-utils/blob/master/CHANGELOG.md`, so `../releases` resulted in a 404.